### PR TITLE
Implement consume and commit using offset

### DIFF
--- a/src/main/kotlin/com/example/messagequeue/controllers/ProducerController.http
+++ b/src/main/kotlin/com/example/messagequeue/controllers/ProducerController.http
@@ -14,11 +14,3 @@ Content-Type: application/json
 {
   "topicId": "test"
 }
-
-###
-POST http://localhost:8080/consume
-Content-Type: application/json
-
-{
-  "topicId": "test"
-}

--- a/src/main/kotlin/com/example/messagequeue/core/OffsetManager.kt
+++ b/src/main/kotlin/com/example/messagequeue/core/OffsetManager.kt
@@ -7,11 +7,16 @@ import java.util.concurrent.atomic.AtomicInteger
 class OffsetManager {
     private val offsets = mutableMapOf<Pair<String, String>, AtomicInteger>()
 
-    fun commit(consumerId: String, topicId: String): Int {
+    fun increment(consumerId: String, topicId: String): Int {
         val offsetKey = Pair(consumerId, topicId)
         val offset = offsets[offsetKey] ?: throw RuntimeException("Invalid key, $topicId, $consumerId")
 
         return offset.incrementAndGet()
+    }
+
+    fun getOffset(consumerId: String, topicId: String): Int {
+        val offsetKey = Pair(consumerId, topicId)
+        return offsets.getOrPut(offsetKey) { AtomicInteger(0) }.get()
     }
 }
 

--- a/src/main/kotlin/com/example/messagequeue/core/TopicManager.kt
+++ b/src/main/kotlin/com/example/messagequeue/core/TopicManager.kt
@@ -18,8 +18,9 @@ class TopicManager(
 
     override fun consume(topicId: String, consumerId: String): Event? {
         val topic = topicToQueueMap[topicId] ?: throw IllegalArgumentException("Topic not found")
+        val offset = offsetManager.getOffset(consumerId, topicId)
         synchronized(topic) {
-            return topic.removeFirstOrNull()
+            return topic[offset]
         }
     }
 
@@ -43,7 +44,7 @@ class TopicManager(
     fun commit(topicId: String, consumerId: String): Int {
         require(isValidTopicId(topicId)) { "Unregistered consumer $consumerId" }
 
-        return offsetManager.commit(
+        return offsetManager.increment(
             topicId = topicId,
             consumerId = consumerId
         )

--- a/src/test/kotlin/com/example/messagequeue/core/OffsetManagerTest.kt
+++ b/src/test/kotlin/com/example/messagequeue/core/OffsetManagerTest.kt
@@ -1,0 +1,53 @@
+import com.example.messagequeue.core.OffsetManager
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class OffsetManagerTest {
+
+    private val offsetManager = OffsetManager()
+
+    @Test
+    fun `increment should increase offset by one`() {
+        val consumerId = "consumer1"
+        val topicId = "topic1"
+
+        val initialOffset = offsetManager.getOffset(topicId, consumerId)
+        offsetManager.increment(topicId, consumerId)
+        val incrementedOffset = offsetManager.getOffset(topicId, consumerId)
+
+        assertEquals(initialOffset + 1, incrementedOffset)
+    }
+
+    @Test
+    fun `increment should throw exception for invalid key`() {
+        val consumerId = "invalidConsumer"
+        val topicId = "invalidTopic"
+
+        assertThrows<RuntimeException> {
+            offsetManager.increment(consumerId, topicId)
+        }
+    }
+
+    @Test
+    fun `getOffset should return zero for new key`() {
+        val consumerId = "newConsumer"
+        val topicId = "newTopic"
+
+        val offset = offsetManager.getOffset(topicId, consumerId)
+
+        assertEquals(0, offset)
+    }
+
+    @Test
+    fun `getOffset should return current offset for existing key`() {
+        val consumerId = "consumer1"
+        val topicId = "topic1"
+        offsetManager.getOffset(topicId, consumerId)
+
+        val expectedOffset = offsetManager.increment(topicId, consumerId)
+        val actualOffset = offsetManager.getOffset(topicId, consumerId)
+
+        assertEquals(expectedOffset, actualOffset)
+    }
+}

--- a/src/test/kotlin/com/example/messagequeue/test/KotestUseTest.kt
+++ b/src/test/kotlin/com/example/messagequeue/test/KotestUseTest.kt
@@ -1,5 +1,6 @@
 package com.example.messagequeue.test
 
+import com.example.messagequeue.core.OffsetManager
 import com.example.messagequeue.core.TopicManager
 import com.example.messagequeue.model.Event
 import io.kotest.core.spec.style.BehaviorSpec
@@ -10,7 +11,7 @@ class KotestUseTest :
     BehaviorSpec({
         context("multi thread setting") {
             Given("100 threads") {
-                val manager = TopicManager()
+                val manager = TopicManager(OffsetManager())
                 val iterationCount = 100_000
                 val threadCount = 100
                 val experimentCount = 20
@@ -46,11 +47,12 @@ class KotestUseTest :
                 }
             }
             Given("100,000 events") {
-                val manager = TopicManager()
+                val manager = TopicManager(OffsetManager())
                 val topicId = "test-topic"
                 val experimentCount = 20
                 val iterationCount = 100_000
                 val threadCount = 100
+                val consumerId = "test-consumer"
 
                 manager.addTopic(topicId)
 
@@ -69,7 +71,7 @@ class KotestUseTest :
                         val executors = Executors.newFixedThreadPool(threadCount)
                         repeat(iterationCount) {
                             executors.submit {
-                                manager.consume(topicId)
+                                manager.consume(topicId, consumerId)
                             }
                         }
                         executors.shutdown()


### PR DESCRIPTION
offset을 사용해서 consume과 commit을 구현합니다.
최초 요청에는 반드시 consume 먼저 호출하기 때문에, consume을 호출하는 시점에 offset이 없다면 생성하도록 합니다.